### PR TITLE
Support for Long and Float specific number types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 sudo: false
 node_js:
-- "5"
-- "6"
+- "8"
+- "10"
 - "node"
 addons:
   apt:

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
-# tiny-msgpack [![Build Status](https://travis-ci.org/JoshuaWise/tiny-msgpack.svg?branch=master)](https://travis-ci.org/JoshuaWise/tiny-msgpack)
+# msgpack-typed-numbers [![Build Status](https://travis-ci.org/mattbishop/msgpack-typed-numbers.svg?branch=master)](https://travis-ci.org/mattbishop/msgpack-typed-numbers)
 
-A minimalistic [MessagePack](http://msgpack.org/index.html) encoder and decoder for JavaScript.
+A minimalistic [MessagePack](http://msgpack.org/index.html) encoder and decoder for JavaScript. Supports typed numbers for 64-bit longs and consistent floating point values. Based on Joshua Wise's excellent [tiny-msgpack](https://github.com/JoshuaWise/tiny-msgpack) project.
 
 - Tiny Size (2.63 kB minified and gzipped)
 - Fast performance (Slightly faster than [msgpack-lite](https://github.com/kawanet/msgpack-lite/))
+- Supports true 64-bit longs and consistent floating-point values
 - Extension support
 - No other bells or whistles
 
@@ -12,22 +13,85 @@ By default, `msgpack` can encode numbers, strings, booleans, nulls, arrays, obje
 ## Installation
 
 ```bash
-npm install --save tiny-msgpack
+npm install --save msgpack-typed-numbers
 ```
 
 ## Usage
 
 ```js
-var msgpack = require('tiny-msgpack');
+var msgpack = require('msgpack-typed-numbers');
 
 var uint8array = msgpack.encode({foo: 'bar', baz: 123});
 var object = msgpack.decode(uint8array);
 ```
 
+## Typed Numbers
+
+Javascript numbers reqpresent both integer and floating point values. This poses two problems for msgpack:
+ 
+1. integer values > 53 bits cannot be represented
+2. floating point values with whole numbers (ie. 1.0) are indistinguishable from integers, so msgpack treats them as integers
+
+When one is using msgpack to send and receive data with other systems that do not have this limitation, like Python or Java, these limitations can ruin the data being transmitted. `msgpack-with-numbers` provides a way to specify Float and Long values to encode and decode numeric data correctly.
+
+### Floating-Point Numbers
+
+To used typed Float values, wrap the value in a `msgpack.Float` class.
+
+```js
+const msgpack = require('msgpack-typed-numbers');
+
+// NOTE: integer number input
+const float1 = new msgpack.Float(100); 
+const float2 = new msgpack.Float(1.1);
+
+const uint8array = msgpack.encode({
+  floatField1: float1, 
+  floatField2: float2
+});
+
+// float1 is encoed as a 32-bit float
+// float2 is encoded as a 64-bit float
+const obj = msgpack.decode(uint8array);
+console.log(obj);
+/* =>
+{ floatField1: 100, floatField2: 1.1 }
+*/
+```
+
+### Long Numbers
+
+To use Long values, create a Long value with the [Long](https://www.npmjs.com/package/long) library.
+
+```js
+const msgpack = require('msgpack-typed-numbers');
+const Long = require('long');
+
+// max 64-bit number
+const long1 = Long.fromBits(-1, 0x7fffffff);
+const long2 = Long.fromNumber(-100);
+
+const uint8array = msgpack.encode({
+  longField1: long1, 
+  longField2: long2, 
+});
+
+// long1 is encoded as a 64-bit uint
+// long2 is encoded as an 8-bit int
+var obj = msgpack.decode(uint8array);
+console.log(obj);
+/* =>
+{ longField1: Long { low: -1, high: 2147483647, unsigned: false },
+  longField2: -100 }
+*/
+```
+
+The use of Long and Float are optional. One can still pass primitive JS numbers and they will be treated as variant-type numeric data.
+
 ## Extensions
 
 ```js
-var msgpack = require('tiny-msgpack');
+var msgpack = require('msgpack-typed-numbers');
 var codec = new msgpack.Codec;
 
 function encodeDate(date) {
@@ -45,7 +109,7 @@ console.log(object.timestamp instanceof Date); // => true
 
 ## Browser Support
 
-In the browser, `tiny-msgpack` requires the [Encoding API](https://developer.mozilla.org/en-US/docs/Web/API/Encoding_API), which is currently only implemented by Chrome and Firefox. However, if you polyfill it, this package is supported by the following browsers:
+In the browser, `msgpack-typed-numbers` requires the [Encoding API](https://developer.mozilla.org/en-US/docs/Web/API/Encoding_API), which is currently only implemented by Chrome and Firefox. However, if you polyfill it, this package is supported by the following browsers:
 
 - Chrome 9+
 - Firefox 15+
@@ -55,8 +119,8 @@ In the browser, `tiny-msgpack` requires the [Encoding API](https://developer.moz
 
 ## Zero copy
 
-In the [MessagePack](http://msgpack.org/index.html) format, binary data is encoded as... binary data! To maximize performance, `tiny-msgpack` does not copy binary data when encoding or decoding it. So after decoding, the contents of a returned `Uint8Array` can be affected by modifying the input `Uint8Array` (the same can happen with encoding).
+In the [MessagePack](http://msgpack.org/index.html) format, binary data is encoded as... binary data! To maximize performance, `msgpack-typed-numbers` does not copy binary data when encoding or decoding it. So after decoding, the contents of a returned `Uint8Array` can be affected by modifying the input `Uint8Array` (the same can happen with encoding).
 
 ## License
 
-[MIT](https://github.com/JoshuaWise/tiny-msgpack/blob/master/LICENSE)
+[MIT](https://github.com/mattbishop/tiny-msgpack/blob/master/LICENSE)

--- a/lib/decode.js
+++ b/lib/decode.js
@@ -16,14 +16,14 @@ var readToken = new Array(256);
 // interpretation of the bytes at the given Paper's offset.
 (function (read) {
 	var i;
-	
+
 	// Creates a readToken function that returns a constant value.
 	var constant = function (value) {
 		return function () {
 			return value;
 		};
 	};
-	
+
 	// Transforms the given method to always receive a second argument, which is
 	// a number constant.
 	var fix = function (len, method) {
@@ -31,7 +31,7 @@ var readToken = new Array(256);
 			return method(decoder, len);
 		};
 	};
-	
+
 	// Transforms the given method to always receive a second argument, which is
 	// a number returned by lenFunc when given a Paper.
 	var flex = function (lenFunc, method) {
@@ -39,57 +39,57 @@ var readToken = new Array(256);
 			return method(decoder, lenFunc(decoder));
 		};
 	};
-	
+
 	// positive fixint -- 0x00 - 0x7f
 	for (i=0x00; i<=0x7f; ++i) {
 		readToken[i] = constant(i);
 	}
-	
+
 	// fixmap -- 0x80 - 0x8f
 	for (i=0x80; i<=0x8f; ++i) {
 		readToken[i] = fix(i - 0x80, read.map);
 	}
-	
+
 	// fixarray -- 0x90 - 0x9f
 	for (i=0x90; i<=0x9f; ++i) {
 		readToken[i] = fix(i - 0x90, read.array);
 	}
-	
+
 	// fixstr -- 0xa0 - 0xbf
 	for (i=0xa0; i<=0xbf; ++i) {
 		readToken[i] = fix(i - 0xa0, read.str);
 	}
-	
+
 	// nil -- 0xc0
 	readToken[0xc0] = constant(null);
-	
+
 	// (never used) -- 0xc1
 	readToken[0xc1] = null;
-	
+
 	// false -- 0xc2
 	// true -- 0xc3
 	readToken[0xc2] = constant(false);
 	readToken[0xc3] = constant(true);
-	
+
 	// bin 8 -- 0xc4
 	// bin 16 -- 0xc5
 	// bin 32 -- 0xc6
 	readToken[0xc4] = flex(read.uint8, read.bin);
 	readToken[0xc5] = flex(read.uint16, read.bin);
 	readToken[0xc6] = flex(read.uint32, read.bin);
-	
+
 	// ext 8 -- 0xc7
 	// ext 16 -- 0xc8
 	// ext 32 -- 0xc9
 	readToken[0xc7] = flex(read.uint8, read.ext);
 	readToken[0xc8] = flex(read.uint16, read.ext);
 	readToken[0xc9] = flex(read.uint32, read.ext);
-	
+
 	// float 32 -- 0xca
 	// float 64 -- 0xcb
 	readToken[0xca] = read.float32;
 	readToken[0xcb] = read.float64;
-	
+
 	// uint 8 -- 0xcc
 	// uint 16 -- 0xcd
 	// uint 32 -- 0xce
@@ -97,8 +97,8 @@ var readToken = new Array(256);
 	readToken[0xcc] = read.uint8;
 	readToken[0xcd] = read.uint16;
 	readToken[0xce] = read.uint32;
-	readToken[0xcf] = null;
-	
+	readToken[0xcf] = read.uint64;
+
 	// int 8 -- 0xd0
 	// int 16 -- 0xd1
 	// int 32 -- 0xd2
@@ -106,8 +106,8 @@ var readToken = new Array(256);
 	readToken[0xd0] = read.int8;
 	readToken[0xd1] = read.int16;
 	readToken[0xd2] = read.int32;
-	readToken[0xd3] = null;
-	
+	readToken[0xd3] = read.int64;
+
 	// fixext 1 -- 0xd4
 	// fixext 2 -- 0xd5
 	// fixext 4 -- 0xd6
@@ -118,24 +118,24 @@ var readToken = new Array(256);
 	readToken[0xd6] = fix(4, read.ext);
 	readToken[0xd7] = fix(8, read.ext);
 	readToken[0xd8] = fix(16, read.ext);
-	
+
 	// str 8 -- 0xd9
 	// str 16 -- 0xda
 	// str 32 -- 0xdb
 	readToken[0xd9] = flex(read.uint8, read.str);
 	readToken[0xda] = flex(read.uint16, read.str);
 	readToken[0xdb] = flex(read.uint32, read.str);
-	
+
 	// array 16 -- 0xdc
 	// array 32 -- 0xdd
 	readToken[0xdc] = flex(read.uint16, read.array);
 	readToken[0xdd] = flex(read.uint32, read.array);
-	
+
 	// map 16 -- 0xde
 	// map 32 -- 0xdf
 	readToken[0xde] = flex(read.uint16, read.map);
 	readToken[0xdf] = flex(read.uint32, read.map);
-	
+
 	// negative fixint -- 0xe0 - 0xff
 	for (i=0xe0; i<=0xff; ++i) {
 		readToken[i] = constant(i - 0x100);

--- a/lib/encode.js
+++ b/lib/encode.js
@@ -1,4 +1,6 @@
 'use strict';
+var Long = require('long');
+
 var writeType = {};
 
 var encode = module.exports = function (encoder, value) {
@@ -8,13 +10,13 @@ var encode = module.exports = function (encoder, value) {
 // Fills the writeType hash with functions that each encode values of their
 // respective types at the given Paper's offset.
 (function (write, fromString) {
-	
+
 	var float32Buffer = new Float32Array(1);
 	var isFloat32 = function (num) {
 		float32Buffer[0] = num;
 		return float32Buffer[0] === num;
 	};
-	
+
 	writeType.number = function (encoder, value) {
 		var uivalue = value >>> 0;
 		if (value === uivalue) {
@@ -44,11 +46,11 @@ var encode = module.exports = function (encoder, value) {
 			}
 		}
 	};
-	
+
 	writeType.string = function (encoder, value) {
 		var utf8 = fromString(value);
 		var byteLength = utf8.byteLength;
-		
+
 		// fixstr -- 0xa0 - 0xbf
 		// str 8 -- 0xd9
 		// str 16 -- 0xda
@@ -57,63 +59,79 @@ var encode = module.exports = function (encoder, value) {
 		byteLength <= 0xff ? write.int8(encoder, 0xd9, byteLength) :
 		byteLength <= 0xffff ? write.int16(encoder, 0xda, byteLength) :
 		write.int32(encoder, 0xdb, byteLength);
-		
+
 		encoder.send(utf8);
 	};
-	
+
 	writeType.boolean = function (encoder, value) {
 		// false -- 0xc2
 		// true -- 0xc3
 		write.type(encoder, value ? 0xc3 : 0xc2);
 	};
-	
+
 	writeType.object = function (encoder, value) {
 		var packer;
-		if (value === null) return nil(encoder, value);
+		if (value === null) return nil(encoder);
 		if (Array.isArray(value)) return array(encoder, value);
 		if (value instanceof Uint8Array) return bin(encoder, value);
+		if (Long.isLong(value)) {
+			return long(encoder, value);
+		}
 		if (encoder.codec && (packer = encoder.codec._packerFor(value))) {
 			return ext(encoder, packer(value));
 		}
 		map(encoder, value);
 	};
-	
+
 	var nil = function (encoder) {
 		// nil -- 0xc0
 		write.type(encoder, 0xc0);
 	};
-	
+
 	var array = function (encoder, value) {
 		var length = value.length;
-		
+
 		// fixarray -- 0x90 - 0x9f
 		// array 16 -- 0xdc
 		// array 32 -- 0xdd
 		length < 16 ? write.type(encoder, 0x90 + length) :
 		length <= 0xffff ? write.int16(encoder, 0xdc, length) :
 		write.int32(encoder, 0xdd, length);
-		
+
 		for (var i=0; i<length; ++i) {
 			encode(encoder, value[i]);
 		}
 	};
-	
+
 	var bin = function (encoder, value) {
 		var byteLength = value.byteLength;
-		
+
 		// bin 8 -- 0xc4
 		// bin 16 -- 0xc5
 		// bin 32 -- 0xc6
 		byteLength <= 0xff ? write.int8(encoder, 0xc4, byteLength) :
 		byteLength <= 0xffff ? write.int16(encoder, 0xc5, byteLength) :
 		write.int32(encoder, 0xc6, byteLength);
-		
+
 		encoder.send(value);
 	};
-	
+
+  var long = function (encoder, value) {
+		if ((value.high === 0 && value.low > -1) || (value.high === -1 && value.low < 0)) {
+			writeType.number(encoder, value.low);
+			return;
+		}
+		// 64-bit number
+		// int 64 -- 0xd3
+		// uint 64 -- 0xcf
+		write.type(encoder, value.high < 0 ? 0xd3 : 0xcf);
+		var bytes = value.toBytesBE();
+		encoder.send(Uint8Array.from(bytes));
+  }
+
 	var ext = function (encoder, value) {
 		var byteLength = value.buffer.byteLength;
-		
+
 		// fixext 1 -- 0xd4
 		// fixext 2 -- 0xd5
 		// fixext 4 -- 0xd6
@@ -130,28 +148,28 @@ var encode = module.exports = function (encoder, value) {
 		byteLength <= 0xff ? (write.int8(encoder, 0xc7, byteLength), write.type(encoder, value.etype)) :
 		byteLength <= 0xffff ? (write.int16(encoder, 0xc8, byteLength), write.type(encoder, value.etype)) :
 		(write.int32(encoder, 0xc9, byteLength), write.type(encoder, value.etype));
-		
+
 		encoder.send(value.buffer);
 	};
-	
+
 	var map = function (encoder, value) {
 		var keys = Object.keys(value);
 		var length = keys.length;
-		
+
 		// fixmap -- 0x80 - 0x8f
 		// map 16 -- 0xde
 		// map 32 -- 0xdf
 		length < 16 ? write.type(encoder, 0x80 + length) :
 		length <= 0xffff ? write.int16(encoder, 0xde, length) :
 		write.int32(encoder, 0xdf, length);
-		
+
 		for (var i=0; i<length; ++i) {
 			var key = keys[i];
 			(key >>> 0) + '' === key ? encode(encoder, key >>> 0) : encode(encoder, key);
 			encode(encoder, value[key]);
 		}
 	};
-	
+
 	writeType.undefined = nil;
 	writeType.function = nil;
 	writeType.symbol = nil;

--- a/lib/encode.js
+++ b/lib/encode.js
@@ -1,4 +1,5 @@
 'use strict';
+var Float = require('./float');
 var Long = require('long');
 
 var writeType = {};
@@ -74,6 +75,9 @@ var encode = module.exports = function (encoder, value) {
 		if (value === null) return nil(encoder);
 		if (Array.isArray(value)) return array(encoder, value);
 		if (value instanceof Uint8Array) return bin(encoder, value);
+		if (Float.isFloat(value)) {
+			return float(encoder, value);
+		}
 		if (Long.isLong(value)) {
 			return long(encoder, value);
 		}
@@ -115,6 +119,12 @@ var encode = module.exports = function (encoder, value) {
 
 		encoder.send(value);
 	};
+
+	var float = function (encoder, value) {
+		value.isSinglePrecision(value)
+			? write.float32(encoder, value.value)  // float 32 -- 0xca
+			: write.float64(encoder, value.value); // float 64 -- 0xcb
+	}
 
   var long = function (encoder, value) {
 		if ((value.high === 0 && value.low > -1) || (value.high === -1 && value.low < 0)) {

--- a/lib/float.js
+++ b/lib/float.js
@@ -1,0 +1,19 @@
+'use strict';
+
+function Float (value) {
+	this.value = value;
+}
+
+Float.prototype.isSinglePrecision = function isSinglePrecision () {
+	return this.value === Math.fround(this.value);
+}
+
+Float.prototype.__isFloat__;
+
+Object.defineProperty(Float.prototype, '__isFloat__', {value: true});
+
+Float.isFloat = function isFloat (obj) {
+	return (obj && obj['__isFloat__']) === true;
+}
+
+module.exports = Float;

--- a/lib/msgpack.js
+++ b/lib/msgpack.js
@@ -1,6 +1,7 @@
 'use strict';
 var Codec = require('./codec');
 var Paper = require('./paper');
+var Float = require('./float');
 var encode = require('./encode');
 var decode = require('./decode');
 
@@ -24,3 +25,4 @@ exports.decode = function (input, codec) {
 	return decode(decoder);
 };
 exports.Codec = Codec;
+exports.Float = Float;

--- a/lib/read-format.js
+++ b/lib/read-format.js
@@ -1,6 +1,7 @@
 'use strict';
 var BufferUtil = require('./buffer-util');
 var decode = require('./decode');
+var Long = require('long');
 
 var map = function (decoder, len) {
 	var value = {};
@@ -65,6 +66,14 @@ var uint32 = function (decoder) {
 		buffer[decoder.offset++]);
 };
 
+var uint64 = function (decoder) {
+	var buffer = decoder.buffer;
+	var offset = decoder.offset;
+	decoder.offset += 8;
+	var bufferView = buffer.subarray(offset, decoder.offset);
+	return Long.fromBytesBE(bufferView, true);
+};
+
 var int8 = function (decoder) {
 	var val = uint8(decoder);
 	return !(val & 0x80) ? val : (0xff - val + 1) * -1;
@@ -82,6 +91,14 @@ var int32 = function (decoder) {
 		(buffer[decoder.offset++] << 16) |
 		(buffer[decoder.offset++] << 8) |
 		buffer[decoder.offset++];
+};
+
+var int64 = function (decoder) {
+	var buffer = decoder.buffer;
+  var offset = decoder.offset;
+	decoder.offset += 8;
+  var bufferView = buffer.subarray(offset, decoder.offset);
+  return Long.fromBytesBE(bufferView, false);
 };
 
 var float32 = function (decoder) {
@@ -107,9 +124,11 @@ module.exports = {
 	uint8: uint8,
 	uint16: uint16,
 	uint32: uint32,
+	uint64: uint64,
 	int8: int8,
 	int16: int16,
 	int32: int32,
+	int64: int64,
 	float32: float32,
 	float64: float64
 };

--- a/lib/tiny-msgpack.d.ts
+++ b/lib/tiny-msgpack.d.ts
@@ -1,0 +1,16 @@
+export class Float {
+    readonly value: number;
+
+    constructor(value: number);
+}
+
+export class Codec {
+    constructor();
+
+    register(etype: number, Class: Function, packer: Function | Function[], unpacker: Function | Function[]): Codec;
+}
+
+export function decode(input: Uint8Array, codec?: Codec): any;
+
+export function encode(input: any, codec?: Codec): Uint8Array;
+

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.2",
   "description": "A minimalistic MessagePack encoder and decoder for JavaScript.",
   "main": "lib/index.js",
+  "types": "lib/tiny-msgpack.d.ts",
   "browser": "browser.js",
   "scripts": {
     "test": "$(npm bin)/mocha",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "tiny-msgpack",
-  "version": "1.0.2",
-  "description": "A minimalistic MessagePack encoder and decoder for JavaScript.",
+  "name": "msgpack-typed-numbers",
+  "version": "0.0.0",
+  "description": "A minimalistic MessagePack encoder and decoder for JavaScript. Supports typed numbers.",
   "main": "lib/index.js",
   "types": "lib/tiny-msgpack.d.ts",
   "browser": "browser.js",
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/JoshuaWise/tiny-msgpack.git"
+    "url": "https://github.com/mattbishop/tiny-msgpack.git"
   },
   "keywords": [
     "binary",
@@ -20,14 +20,20 @@
     "messagepack",
     "serialize",
     "encode",
-    "decode"
+    "decode",
+    "long",
+    "float",
+    "double"
   ],
   "author": "Joshua Wise <joshuathomaswise@gmail.com>",
+  "contributors": [
+    "Matt Bishop <matt@thebishops.org>"
+  ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/JoshuaWise/tiny-msgpack/issues"
+    "url": "https://github.com/mattbishop/tiny-msgpack/issues"
   },
-  "homepage": "https://github.com/JoshuaWise/tiny-msgpack#readme",
+  "homepage": "https://github.com/mattbishop/tiny-msgpack#readme",
   "devDependencies": {
     "benchmark": "^2.1.2",
     "chai": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -29,10 +29,13 @@
   "homepage": "https://github.com/JoshuaWise/tiny-msgpack#readme",
   "devDependencies": {
     "benchmark": "^2.1.2",
-    "chai": "^3.5.0",
+    "chai": "^4.2.0",
     "cli-color": "^1.1.0",
-    "mocha": "^3.1.2",
+    "mocha": "^5.2.0",
     "msgpack": "^1.0.2",
     "msgpack-lite": "^0.1.26"
+  },
+  "dependencies": {
+    "long": "^4.0.0"
   }
 }

--- a/test/10.encode.js
+++ b/test/10.encode.js
@@ -3,6 +3,7 @@ var encode = require('../.').encode;
 var referenceEncode = require('msgpack-lite').encode;
 var referenceDecode = require('msgpack-lite').decode;
 var util = require('util');
+var Long = require('long');
 var expect = require('chai').expect;
 
 function expectCorrectLength(value, expectedBytes) {
@@ -105,6 +106,17 @@ describe('msgpack.encode()', function () {
 		expectToEqualReference(stringOf(256), 259);
 		expectToEqualReference(stringOf(65535), 65538);
 		expectToEqualReference(stringOf(65536), 65541);
+	});
+	specify('long', function () {
+		expectCorrectLength(Long.fromNumber(0), 1);
+		expectCorrectLength(Long.fromNumber(32768), 3);
+		expectCorrectLength(Long.fromNumber(-32768), 3);
+		expectCorrectLength(Long.fromNumber(0x7fffffff), 5);
+		expectCorrectLength(Long.fromNumber(-0x80000000), 5);
+		expectCorrectLength(Long.fromNumber(Number.MIN_SAFE_INTEGER), 9);
+		expectCorrectLength(Long.fromNumber(Number.MAX_SAFE_INTEGER), 9);
+		expectCorrectLength(Long.fromBits(-1, 0x7fffffff), 9);
+		expectCorrectLength(Long.fromBits(0, -0x80000000), 9);
 	});
 	specify('binary', function () {
 		function expectToEqualReferenceBinary(value, expectedBytes) {

--- a/test/10.encode.js
+++ b/test/10.encode.js
@@ -1,5 +1,6 @@
 'use strict';
 var encode = require('../.').encode;
+var Float = require('./..').Float;
 var referenceEncode = require('msgpack-lite').encode;
 var referenceDecode = require('msgpack-lite').decode;
 var util = require('util');
@@ -106,6 +107,10 @@ describe('msgpack.encode()', function () {
 		expectToEqualReference(stringOf(256), 259);
 		expectToEqualReference(stringOf(65535), 65538);
 		expectToEqualReference(stringOf(65536), 65541);
+	});
+	specify('float', function () {
+		expectCorrectLength(new Float(1.0), 5);
+		expectCorrectLength(new Float(1.01), 9);
 	});
 	specify('long', function () {
 		expectCorrectLength(Long.fromNumber(0), 1);

--- a/test/11.decode.js
+++ b/test/11.decode.js
@@ -3,6 +3,7 @@ var encode = require('../.').encode;
 var decode = require('../.').decode;
 var referenceDecode = require('msgpack-lite').decode;
 var util = require('util');
+var Long = require('long');
 var expect = require('chai').expect;
 
 function expectToDecodeLikeReference(value) {
@@ -14,6 +15,11 @@ function expectToDecodeExactly(value) {
 	var encoded = encode(value);
 	expect(decode(encoded)).to.deep.equal(value);
 	expect(decode(encoded)).to.deep.equal(referenceDecode(Buffer.from(encoded)));
+}
+
+function expectToDecodeExactlyWithoutReference(value) {
+	var encoded = encode(value);
+	expect(decode(encoded)).to.deep.equal(value);
 }
 
 function stringOf(length) {
@@ -93,6 +99,12 @@ describe('msgpack.decode()', function () {
 		expectToDecodeExactly(stringOf(256));
 		expectToDecodeExactly(stringOf(65535));
 		expectToDecodeExactly(stringOf(65536));
+	});
+	specify('long', function () {
+		expectToDecodeExactlyWithoutReference(Long.fromNumber(Number.MIN_SAFE_INTEGER));
+		expectToDecodeExactlyWithoutReference(Long.fromNumber(Number.MAX_SAFE_INTEGER, true));
+		expectToDecodeExactlyWithoutReference(Long.fromBits(0, -0x80000000));
+		expectToDecodeExactlyWithoutReference(Long.fromBits(-1, 0x7fffffff, true));
 	});
 	specify('binary', function () {
 		function expectToDecodeExactBinary(value) {

--- a/test/11.decode.js
+++ b/test/11.decode.js
@@ -1,6 +1,7 @@
 'use strict';
 var encode = require('../.').encode;
 var decode = require('../.').decode;
+var Float = require('../.').Float;
 var referenceDecode = require('msgpack-lite').decode;
 var util = require('util');
 var Long = require('long');
@@ -99,6 +100,17 @@ describe('msgpack.decode()', function () {
 		expectToDecodeExactly(stringOf(256));
 		expectToDecodeExactly(stringOf(65535));
 		expectToDecodeExactly(stringOf(65536));
+	});
+	specify('float', function () {
+		var expectDecodeForFloat = function (value) {
+			var float = new Float(value);
+			var encoded = encode(float);
+			expect(decode(encoded)).to.equal(float.value);
+		};
+		// 32-bit
+		expectDecodeForFloat(1.0);
+		// 64-bit
+		expectDecodeForFloat(-1.1);
 	});
 	specify('long', function () {
 		expectToDecodeExactlyWithoutReference(Long.fromNumber(Number.MIN_SAFE_INTEGER));


### PR DESCRIPTION
Msgpack implementations on other platforms usually expect number formats to be in specific families like int and float. They do not do well when a value can be _either_ int or float. Javascript's number type cannot be reliably pinned to be a float or an int, so tiny-msgpack (and msgpack-lite) make a best-guess effort to pick the right msgpack family.

This is not always acceptable for cross-platform message formats that use msgpack. This PR brings in support for specifying the number more specifically. One can encode a `Float` instance and it will be encoded as float-32 or float-64, even if the value is an int, like 1.0.

Similarly, if one has an int that is greater than 32 bits in length then you can now pass in a `Long` instance and see it encoded as either uint64 or int-64.  This change adds a dependency on the `long` library, which is a pretty safe dependency.

If you don't want to accept this PR, please let me know and I can release a new version of tiny-msgpack with these changes for my own purposes.