### PR TITLE
Accept Uint8ClampedArray objects for decoding

### DIFF
--- a/lib/msgpack.js
+++ b/lib/msgpack.js
@@ -16,8 +16,8 @@ exports.decode = function (input, codec) {
 	if (codec != null && !(codec instanceof Codec)) {
 		throw new TypeError('Expected second argument to be a Codec, if provided.');
 	}
-	if (!(input instanceof Uint8Array)) {
-		throw new TypeError('Expected first argument to be a Uint8Array.');
+	if (!(input instanceof Uint8Array) && !(input instanceof Uint8ClampedArray)) {
+		throw new TypeError('Expected first argument to be a Uint8Array or Uint8ClampedArray.');
 	}
 	var decoder = new Paper(codec);
 	decoder.setBuffer(input);


### PR DESCRIPTION
Current decoder accepts only Uint8Array objects while correctly working with Uint8ClampedArrays as well. I modified the check to accept Uint8ClampedArrays objects as well.